### PR TITLE
Giteaのactionで対応していないものに対しては投稿しないように

### DIFF
--- a/router/gitea/gitea.go
+++ b/router/gitea/gitea.go
@@ -100,6 +100,7 @@ func (c *converter) handleIssuesEvent(payload *issueEvent) (string, error) {
 	var m strings.Builder
 	m.WriteString("### ")
 
+	// https://github.com/traPtitech/gitea/blob/8abe54a9d4db1fdce7c517dc500a51e77d1f2c16/modules/structs/hook.go#L321-L350
 	switch payload.Action {
 	case "opened":
 		m.WriteString(fmt.Sprintf(":git_issue_opened: %s Opened by `%s`\n", issueName, senderName))
@@ -130,6 +131,8 @@ func (c *converter) handleIssuesEvent(payload *issueEvent) (string, error) {
 		m.WriteString(fmt.Sprintf(":git_issue_closed: %s Closed by `%s`\n", issueName, senderName))
 	case "reopened":
 		m.WriteString(fmt.Sprintf(":git_issue_opened: %s Reopened by `%s`\n", issueName, senderName))
+	default:
+		return "", nil
 	}
 
 	return m.String(), nil
@@ -181,6 +184,7 @@ func (c *converter) handlePullRequestEvent(payload *pullRequestEvent) (string, e
 	m.WriteString("### ")
 	prName := fmt.Sprintf("Pull Request [#%v %s](%s)", payload.PullRequest.Number, payload.PullRequest.Title, payload.PullRequest.HTMLURL)
 
+	// https://github.com/traPtitech/gitea/blob/8abe54a9d4db1fdce7c517dc500a51e77d1f2c16/modules/structs/hook.go#L321-L350
 	switch payload.Action {
 	case "opened":
 		m.WriteString(fmt.Sprintf(":git_pull_request: %s Opened by `%s`\n", prName, senderName))
@@ -218,6 +222,8 @@ func (c *converter) handlePullRequestEvent(payload *pullRequestEvent) (string, e
 		}
 	case "reopened":
 		m.WriteString(fmt.Sprintf(":git_pull_request: %s Reopened by `%s`\n", prName, senderName))
+	default:
+		return "", nil
 	}
 
 	return m.String(), nil
@@ -229,6 +235,7 @@ func (c *converter) handlePullRequestReviewEvent(payload *pullRequestEvent, stat
 	m.WriteString("### ")
 	prName := fmt.Sprintf("Pull Request [#%v %s](%s)", payload.PullRequest.Number, payload.PullRequest.Title, payload.PullRequest.HTMLURL)
 
+	// https://github.com/traPtitech/gitea/blob/8abe54a9d4db1fdce7c517dc500a51e77d1f2c16/modules/webhook/type.go#L10-L34
 	switch status {
 	case "approved":
 		m.WriteString(fmt.Sprintf(":white_check_mark: %s Approved by `%s`", prName, senderName))
@@ -236,6 +243,8 @@ func (c *converter) handlePullRequestReviewEvent(payload *pullRequestEvent, stat
 		m.WriteString(fmt.Sprintf(":comment: %s New Review Comment by `%s`", prName, senderName))
 	case "rejected":
 		m.WriteString(fmt.Sprintf(":comment: %s Changes Requested by `%s`", prName, senderName))
+	default:
+		return "", nil
 	}
 	if payload.Review.Content != "" {
 		m.WriteString("\n---\n")


### PR DESCRIPTION
https://q.trap.jp/messages/f4e7ab0a-de06-4f54-b1ad-952d86c276b7 への雑な対処です

このメッセージは`pull_request`イベントで、↓のペイロード(主要部分のみ抜粋)に対して発行されたものです。

```jsonc
{
  "action": "review_requested",
  "number": 10,
  "pull_request": {
    // ...
  },
  "requested_reviewer": {
    // ...
  },
  "repository": {
    // ...
  },
  "sender": {
    // ...
  },
  "commit_id": "",
  "review": null
}
```

現状のコードでは`review_requested`アクションに対しては`### `のみを投稿するようになっていたため、未対応のアクションに対しては投稿しないようにしました。他のgiteaイベントに対しても同様の処置を施してあります。